### PR TITLE
Change to https from http

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -8,7 +8,7 @@ export class AuthService {
   // private USER_BASE_URL: string = 'http://localhost:5000/auth';
   private USER_BASE_URL: string = 'https://science-gateway-users.azurewebsites.net/auth';
   // private COUNTER_BASE_URL: string = 'http://localhost:5000/api';
-  private COUNTER_BASE_URL: string = 'http://science-gateway-count.azurewebsites.net/api';
+  private COUNTER_BASE_URL: string = 'https://science-gateway-count.azurewebsites.net/api';
 
   private headers: Headers = new Headers({'Content-Type': 'application/json'});
   constructor(private http: Http) {}

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -13,11 +13,7 @@ import * as urljoin from 'url-join';
 
 @Injectable()
 export class DashboardService {
-  // private jobsUrl = require('../../assets/job_status.json');
-  // private jobsUrl = 'http://localhost:5000/api/jobs';
-  // apiRoot: 'http://dev-science-gateway-middleware.azurewebsites.net/api/',
-  // private progressUrl = require('../../assets/progress.json')
-  //private progressUrl = 'http://localhost:5000/api/progress/';
+  
   private jobsUrl = urljoin(environment.apiRoot, "jobs")
   private progressUrl = urljoin(environment.apiRoot, "progress")
   private cancelUrl = urljoin(environment.apiRoot, "cancel")

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -3,6 +3,6 @@ import { Environment } from './environment.interface';
 export const environment: Environment = {
     target: 'dev',
     // apiRoot: 'http://localhost:5000/api/',
-    apiRoot: 'http://science-gateway-middleware-dev.azurewebsites.net/api/',
+    apiRoot: 'https://science-gateway-middleware-dev.azurewebsites.net/api/',
     production: false
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,6 +2,6 @@ import { Environment } from './environment.interface';
 
 export const environment: Environment = {
     target: 'prod',
-    apiRoot: 'http://science-gateway-middleware-dev.azurewebsites.net/api/',
+    apiRoot: 'https://science-gateway-middleware-dev.azurewebsites.net/api/',
     production: true
 }


### PR DESCRIPTION
Now that we're moving to https we need to ensure consistent https calls. Otherwise, browsers will respond with errors such as 


```
Mixed Content: The page at 'https://www.bluemultiphase.io/dashboard' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://science-gateway-middleware-dev.azurewebsites.net/api/jobs'. This request has been blocked; the content must be served over HTTPS.
```