### PR TITLE
Add HTTPS redirect to web.config

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,7 +1,14 @@
 <configuration>
     <system.webServer>
          <rewrite>
-            <rules>
+            <rules>            
+			  <rule name="Redirect to https" stopProcessing="false">
+				<match url="(.*)" />
+				<conditions>
+					<add input="{HTTPS}" pattern="off" ignoreCase="true" />
+				</conditions>
+				<action type="Redirect" url="https://{HTTP_HOST}{REQUEST_URI}" redirectType="Permanent" appendQueryString="false" />
+  			  </rule>
               <rule name="AngularJS Routes" stopProcessing="true">
                 <match url=".*" />
                 <conditions logicalGrouping="MatchAll">


### PR DESCRIPTION
We tried adding the extension in the "Easy, no code way" section of [this guide](https://blog.nicholasrogoff.com/2017/01/12/azure-app-service-force-redirect-from-http-to-https-the-easy-way/). However, this appears to attach to a deployment slot.

Rather than add the extension to all deployment slots, we are adding a rewrite rule to the `web.config` file. We have placed this rule **before** the Angular SPA routing rewrite rule and set `stopProcessing` to false, so the Angular rule should still get processed.

We could have combined both into a single rule by prepending `https://` to the Angular rule, but I want to ensure we keep the HTTPS redirect regardless of how the app develops.